### PR TITLE
Call callback depending on packet id

### DIFF
--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -176,7 +176,7 @@ uint8_t Packet::available()
 					bytesRead = 0;
 					status    = NEW_DATA;
 
-					callCallbacks();
+					callCallbacks(idByte);
 
 					return bytesToRec;
 				}
@@ -335,13 +335,17 @@ void Packet::unpackPacket()
 	}
 }
 
-void Packet::callCallbacks()
+void Packet::callCallbacks(int index)
 {
 	CallbackNode* cur = callbacks;
 
-	while (cur != nullptr)
-	{
-		cur->callback(*this);
-		cur = cur->next;
-	}
+    // call callback at postition index in the linked list
+    int count = 0;
+    while (cur != nullptr)
+    {
+        if (count == index)
+			cur->callback(*this);
+        count++;
+        cur = cur->next;
+    }
 }

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -243,5 +243,5 @@ class Packet
 
 	uint8_t stuffPacket();
 	void    unpackPacket();
-	void    callCallbacks();
+	void    callCallbacks(int index);
 };


### PR DESCRIPTION
I am currently using this branch instead of the main repo. But as opposed to the main repo all callbacks get called independent of packet ID. So to use the callbacks for serial commands I changed it to make it again depending on packet ID.